### PR TITLE
docs(zoom): fixed wrong written methods

### DIFF
--- a/src/jade/api/zoom/methods.jade
+++ b/src/jade/api/zoom/methods.jade
@@ -24,8 +24,8 @@ table.methods-table
       td mySwiper.zoom.in();
       td Zoom in image of the currently active slide
     tr
-      td mySwiper.zoom.in();
+      td mySwiper.zoom.out();
       td Zoom out image of the currently active slide
     tr
-      td mySwiper.zoom.in();
+      td mySwiper.zoom.toggle();
       td Toggle image zoom of the currently active slide


### PR DESCRIPTION
These methods where probably copy and pasted and let that way without changing.