### PR TITLE
docs(zoom): rm duplicated toggle method

### DIFF
--- a/src/jade/api/zoom/methods.jade
+++ b/src/jade/api/zoom/methods.jade
@@ -18,9 +18,6 @@ table.methods-table
       td mySwiper.zoom.disable();
       td Disable zoom module
     tr
-      td mySwiper.zoom.toggle();
-      td Toggle image zoom of the currently active slide
-    tr
       td mySwiper.zoom.in();
       td Zoom in image of the currently active slide
     tr


### PR DESCRIPTION
Maybe it should be enable, disable, toggle, or in, out, toggle. I'm not sure, but the actual behavior stands to zoom in/out toggle.