### PR TITLE
Caution for spaceBetween is added

### DIFF
--- a/src/jade/api/params.jade
+++ b/src/jade/api/params.jade
@@ -96,7 +96,9 @@ table.params-table
       td spaceBetween
       td number
       td 0
-      td Distance between slides in px.
+      td 
+        p Distance between slides in px.
+        p.important-note If you use "margin" css property to the elements which go into Swiper in which you pass "spaceBetween" into, <b>navigation</b> might not work property.
     tr
       td slidesPerView
       td number or 'auto'


### PR DESCRIPTION
Suppose the codes below is what I wrote. 

```jsx
import Swiper from 'react-id-swiper';
const img = ['a.png', 'b.png', 'c.png'];
const style = { margin: '0 5px' };

const list = () => img.map((d, i) => <img key={i} src={d} style={style} />);
const sliderSetting = { 
  spaceBetween: 10,
  navigation: {
    nextEl: '.swiper-button-next',
    prevEl: '.swiper-button-prev'
  },
};

const swiper = () => (
  <Swiper {...sliderSetting} >
    {list}
  </Swiper>
);
export const swiper;
```

Due to `spaceBetween` property, every elements in Swiper will have `margin` property by default, however, I've also set `margin` property by CSS. Because of this, navigation does not work properly anymore. 

How far the Swiper will be scrolled to down/right on the next scroll depends on the codes below, I think.

```ts
// eslint-disable-next-line
// swiper.js line 1391
if (swiper.isHorizontal()) {
  slideSize = slide[0].getBoundingClientRect().width
    + parseFloat(slideStyles.getPropertyValue('margin-left'))
    + parseFloat(slideStyles.getPropertyValue('margin-right'));
 } else {
  slideSize = slide[0].getBoundingClientRect().height
    + parseFloat(slideStyles.getPropertyValue('margin-top'))
    + parseFloat(slideStyles.getPropertyValue('margin-bottom'));
 }
```

So I had to see my swiper working very weird when I navigated to the next page since I've put CSS styles of `margin`. It took ages to figure out what I did wrong. 

That's why I think we need more explanation for users to prevent from this unexpected side-effect.
Thanks.
