### PR TITLE
Update Vue Example to carry down scope from Vue

### DIFF
--- a/src/jade/api/virtual/example.jade
+++ b/src/jade/api/virtual/example.jade
@@ -79,17 +79,14 @@ pre
           }
         }
         componentDidMount() {
-          const self = this;
           const swiper = new Swiper('.swiper-container', {
             // ...
             virtual: {
-              slides: self.state.slides,
-              renderExternal(data) {
+              slides: this.state.slides,
+              renderExternal: (data) => {
                 // assign virtual slides data
-                self.setState({
-                  virtualData: data,
-                });
-              }
+                this.virtualData = data
+              },
             },
           });
         }


### PR DESCRIPTION
Uses arrow function for renderExternal so the scope(this.) is carried down into the function and Vue can be referenced easier. 