### PR TITLE
Add documentation for three new parameters in a11y component

### DIFF
--- a/src/pug/api/a11y/params.pug
+++ b/src/pug/api/a11y/params.pug
@@ -59,5 +59,20 @@ table.params-table
       td string
       td 'swiper-notification'
       td CSS class name of a11y notification
+    tr.subparam-row
+      td containerMessage
+      td string
+      td null
+      td Message for screen readers for outer swiper container
+    tr.subparam-row
+      td containerRoleDescriptionMessage
+      td string
+      td null
+      td Message for screen readers describing the role of outer swiper container
+    tr.subparam-row
+      td itemRoleDescriptionMessage
+      td string
+      td null
+      td Message for screen readers describing the role of slide element
     tr.subparam-close-row
       td(colspan="4") }


### PR DESCRIPTION
This pull request is related to https://github.com/nolimits4web/swiper/issues/3149 and the related pull request https://github.com/nolimits4web/swiper/pull/3834.

There are three new parameters for the a11y component:

- containerMessage (String, default null): message for screen readers for outer swiper container
- containerRoleDescriptionMessage (String, default null): message for screen readers describing the role of outer swiper container
- itemRoleDescriptionMessage (String, default null): message for screen readers describing the role of slide element