### PR TITLE
Updated documentation to reflect breakpoint behaviour

### DIFF
--- a/src/pug/api/params.pug
+++ b/src/pug/api/params.pug
@@ -482,21 +482,22 @@ table.params-table
                 spaceBetween: 10,
                 // Responsive breakpoints
                 breakpoints: {
-                  // when window width is &gt;= 320px
+                  // when window width is &lt;= 320px
                   320: {
                     slidesPerView: 2,
                     spaceBetween: 20
                   },
-                  // when window width is &gt;= 480px
+                  // when window width is &lt;= 480px
                   480: {
                     slidesPerView: 3,
                     spaceBetween: 30
                   },
-                  // when window width is &gt;= 640px
+                  // when window width is &lt;= 640px
                   640: {
                     slidesPerView: 4,
                     spaceBetween: 40
                   }
+                  // when window width is &gt; 640px it will use the default parameters
                 }
               })
         p Since version 5.3.0 it also supports "ratio" (width/height) breakpoints:


### PR DESCRIPTION
Breakpoint parameters are 'active' when window width is `<=` given breakpoint.