### PR TITLE
Improve code example to include effect: 'fade'

### DIFF
--- a/src/pug/api/effect-fade/params.pug
+++ b/src/pug/api/effect-fade/params.pug
@@ -18,6 +18,7 @@ table.params-table
             code
               :code(lang="js")
                 var mySwiper = new Swiper('.swiper-container', {
+                  effect: 'fade',
                   fadeEffect: {
                     crossFade: true
                   },


### PR DESCRIPTION
I was trying to implement the fade effect (working with Swiper v 5.4.1) and I didn't notice the little comment on top of the code example, that I need to include `effect: 'fade'`, so it took me awhile to get it working.
I thought it might be helpful for others to have it as part of the code example.