### PR TITLE
fix(angular): use *ngFor on ng-template

### DIFF
--- a/src/pug/angular/index.pug
+++ b/src/pug/angular/index.pug
@@ -239,9 +239,6 @@ block content
           td
           td Actual swiper slide index. Required to be set for virtual slides
 
-    .important-note
-      p
-        b Swiper Angular forces the use of `ng-template` in favor of supporting full featured loop mode.
     ```html
       <swiper>
         <ng-template swiperSlide>

--- a/src/pug/angular/index.pug
+++ b/src/pug/angular/index.pug
@@ -248,12 +248,10 @@ block content
           <div>Slide</div>
         </ng-template>
 
-        <ng-container *ngFor="slide of slides">
-          <ng-template swiperSlide>
-            <div>Slide</div>
-          </ng-template>
-        </ng-container>
-      </swiper>
+        <ng-template swiperSlide *ngFor="slide of slides">
+          <div>Slide</div>
+        </ng-template>
+    </swiper>
     ```
 
     h2.no-border#swiperslide-variables `SwiperSlideDirective` variables
@@ -327,9 +325,7 @@ block content
       @Component({
         selector: 'app-swiper-virtual-example',
         template: ` <swiper [slidesPerView]="3" [spaceBetween]="50" [virtual]="true">
-          <ng-container *ngFor="let slide of slides; index as i">
-            <ng-template swiperSlide>Slide {{ slide }}</ng-template>
-          </ng-container>
+          <ng-template swiperSlide *ngFor="let slide of slides; index as i">Slide {{ slide }}</ng-template>
         </swiper>`,
       })
       export class AppComponent {


### PR DESCRIPTION
I was wrong when said `*ngFor` cant work on `ng-template`. `ng-template` here is actually `swiperSlide` component, so `*ngFor` is working correctly.