### PR TITLE
Added note to Parallax module in swiper-api.mdx

### DIFF
--- a/src/pages/swiper-api.mdx
+++ b/src/pages/swiper-api.mdx
@@ -391,7 +391,7 @@ To enable parallax effects you need to init Swiper with passed `parallax:true` p
       </td>
       <td className="w-1/6 text-red-700 font-mono font-semibold"></td>
       <td className="w-3/6 space-y-2">
-        <p>Object with parallax parameters</p>
+        <p>Object with parallax parameters or boolean <code>true</code> to enable with default settings.</p>
         {/* prettier-ignore */}
         <pre className="language-js"><code className="language-js"><span className="token keyword">const</span>{' '}swiper{' '}<span className="token operator">=</span>{' '}<span className="token keyword">new</span>{' '}<span className="token class-name">Swiper</span><span className="token punctuation">(</span><span className="token string">'.swiper-container'</span><span className="token punctuation">,</span>{' '}<span className="token punctuation">{'{'}</span>{`
 `}{'  '}parallax<span className="token operator">:</span>{' '}<span className="token boolean">true</span><span className="token punctuation">,</span>{`


### PR DESCRIPTION
Updated swiper-api.mdx because the description of the **Parallax** module is hard-coded directly into it.

Same as https://github.com/nolimits4web/swiper/blob/97ac631cc444ffa72448de19e22cd0eaf1b42605/src/types/swiper-options.d.ts#L1123