### PR TITLE
docs: switch from unpkg to jsdelivr

### DIFF
--- a/src/demos/010-default/core/index.html
+++ b/src/demos/010-default/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -81,7 +81,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/020-navigation/core/index.html
+++ b/src/demos/020-navigation/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -83,7 +83,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/030-pagination/core/index.html
+++ b/src/demos/030-pagination/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/040-pagination-dynamic/core/index.html
+++ b/src/demos/040-pagination-dynamic/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/050-pagination-progress/core/index.html
+++ b/src/demos/050-pagination-progress/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/060-pagination-fraction/core/index.html
+++ b/src/demos/060-pagination-fraction/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/070-pagination-custom/core/index.html
+++ b/src/demos/070-pagination-custom/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -98,7 +98,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/080-scrollbar/core/index.html
+++ b/src/demos/080-scrollbar/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/090-vertical/core/index.html
+++ b/src/demos/090-vertical/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/100-space-between/core/index.html
+++ b/src/demos/100-space-between/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/110-slides-per-view/core/index.html
+++ b/src/demos/110-slides-per-view/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/120-slides-per-view-auto/core/index.html
+++ b/src/demos/120-slides-per-view-auto/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -94,7 +94,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/130-centered/core/index.html
+++ b/src/demos/130-centered/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/140-centered-auto/core/index.html
+++ b/src/demos/140-centered-auto/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -94,7 +94,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/145-css-mode/core/index.html
+++ b/src/demos/145-css-mode/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/150-freemode/core/index.html
+++ b/src/demos/150-freemode/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/160-scroll-container/core/index.html
+++ b/src/demos/160-scroll-container/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -181,7 +181,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/170-grid/core/index.html
+++ b/src/demos/170-grid/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -78,7 +78,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/170-slides-per-column/core/index.html
+++ b/src/demos/170-slides-per-column/core/index.html
@@ -6,7 +6,7 @@
   <title>Swiper demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
   <!-- Link Swiper's CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Demo styles -->
   <style>
@@ -73,7 +73,7 @@
   </div>
 
   <!-- Swiper JS -->
-  <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
   <!-- Initialize Swiper -->
   <script>

--- a/src/demos/180-nested/core/index.html
+++ b/src/demos/180-nested/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -93,7 +93,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/190-grab-cursor/core/index.html
+++ b/src/demos/190-grab-cursor/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/200-infinite-loop/core/index.html
+++ b/src/demos/200-infinite-loop/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -89,7 +89,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/210-infinite-loop-with-slides-per-group/core/index.html
+++ b/src/demos/210-infinite-loop-with-slides-per-group/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/211-slides-per-group-skip/core/index.html
+++ b/src/demos/211-slides-per-group-skip/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -143,7 +143,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/220-effect-fade/core/index.html
+++ b/src/demos/220-effect-fade/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -70,7 +70,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/230-effect-cube/core/index.html
+++ b/src/demos/230-effect-cube/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -73,7 +73,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/240-effect-coverflow/core/index.html
+++ b/src/demos/240-effect-coverflow/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -86,7 +86,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/250-effect-flip/core/index.html
+++ b/src/demos/250-effect-flip/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -79,7 +79,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/255-effect-cards/core/index.html
+++ b/src/demos/255-effect-cards/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -126,7 +126,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/257-effect-creative/core/index.html
+++ b/src/demos/257-effect-creative/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -178,7 +178,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/260-keyboard-control/core/index.html
+++ b/src/demos/260-keyboard-control/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/270-mousewheel-control/core/index.html
+++ b/src/demos/270-mousewheel-control/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/280-autoplay/core/index.html
+++ b/src/demos/280-autoplay/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/290-dynamic-slides/core/index.html
+++ b/src/demos/290-dynamic-slides/core/index.html
@@ -6,7 +6,7 @@
   <title>Swiper demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
   <!-- Link Swiper's CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Demo styles -->
   <style>
@@ -105,7 +105,7 @@
   </p>
 
   <!-- Swiper JS -->
-  <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
   <!-- Initialize Swiper -->
   <script>

--- a/src/demos/290-manipulation/core/index.html
+++ b/src/demos/290-manipulation/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -109,7 +109,7 @@
     </p>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/300-thumbs-gallery/core/index.html
+++ b/src/demos/300-thumbs-gallery/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -187,7 +187,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/310-thumbs-gallery-loop/core/index.html
+++ b/src/demos/310-thumbs-gallery-loop/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -187,7 +187,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/320-multiple-swipers/core/index.html
+++ b/src/demos/320-multiple-swipers/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -120,7 +120,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/330-hash-navigation/core/index.html
+++ b/src/demos/330-hash-navigation/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/340-history/core/index.html
+++ b/src/demos/340-history/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/350-rtl/core/index.html
+++ b/src/demos/350-rtl/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -84,7 +84,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/360-parallax/core/index.html
+++ b/src/demos/360-parallax/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -139,7 +139,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/370-lazy-load-images/core/index.html
+++ b/src/demos/370-lazy-load-images/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -135,7 +135,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/380-responsive-breakpoints/core/index.html
+++ b/src/demos/380-responsive-breakpoints/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/381-ratio-breakpoints/core/index.html
+++ b/src/demos/381-ratio-breakpoints/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -82,7 +82,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/390-autoheight/core/index.html
+++ b/src/demos/390-autoheight/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -73,7 +73,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/400-zoom/core/index.html
+++ b/src/demos/400-zoom/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -105,7 +105,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/410-virtual-slides/core/index.html
+++ b/src/demos/410-virtual-slides/core/index.html
@@ -6,7 +6,7 @@
   <title>Swiper demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Link Swiper's CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Demo styles -->
   <style>
@@ -82,7 +82,7 @@
   </p>
 
   <!-- Swiper JS -->
-  <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
   <!-- Initialize Swiper -->
   <script>

--- a/src/demos/420-custom-plugin/core/index.html
+++ b/src/demos/420-custom-plugin/core/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
 
   <!-- Link Swiper's CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Demo styles -->
   <style>
@@ -76,7 +76,7 @@
   </div>
 
   <!-- Swiper JS -->
-  <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
   <!-- Include plugin after Swiper -->
   <script>

--- a/src/demos/430-slideable-menu/core/index.html
+++ b/src/demos/430-slideable-menu/core/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
 
   <!-- Link Swiper's CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Demo styles -->
   <style>
@@ -173,7 +173,7 @@
   </div>
 
   <!-- Swiper JS -->
-  <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
   <!-- Initialize Swiper -->
   <script>

--- a/src/demos/440-change-direction/core/index.html
+++ b/src/demos/440-change-direction/core/index.html
@@ -6,7 +6,7 @@
   <title>Swiper demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Link Swiper's CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css" />
 
   <!-- Demo styles -->
   <style>
@@ -84,7 +84,7 @@
   </div>
 
   <!-- Swiper JS -->
-  <script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 
   <!-- Initialize Swiper -->
   <script>

--- a/src/demos/450-watch-slides-visibility/core/index.html
+++ b/src/demos/450-watch-slides-visibility/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -83,7 +83,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/demos/500-rewind/core/index.html
+++ b/src/demos/500-rewind/core/index.html
@@ -10,7 +10,7 @@
     <!-- Link Swiper's CSS -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swiper/swiper-bundle.min.css"
+      href="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.css"
     />
 
     <!-- Demo styles -->
@@ -83,7 +83,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper/swiper-bundle.min.js"></script>
 
     <!-- Initialize Swiper -->
     <script>

--- a/src/pages/get-started.mdx
+++ b/src/pages/get-started.mdx
@@ -70,17 +70,17 @@ If you don't want to include Swiper files in your project, you may use it from C
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/swiper@8/swiper-bundle.min.css"
+  href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css"
 />
 
-<script src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.js"></script>
 ```
 
 If you use ES modules in browser, there is a CDN version for that too:
 
 ```html
 <script type="module">
-  import Swiper from 'https://unpkg.com/swiper@8/swiper-bundle.esm.browser.min.js'
+  import Swiper from 'https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.esm.browser.min.js'
 
   const swiper = new Swiper(...)
 </script>
@@ -88,7 +88,7 @@ If you use ES modules in browser, there is a CDN version for that too:
 
 ### Download assets
 
-If you want to use Swiper assets locally, you can directly download them from https://unpkg.com/swiper@8/
+If you want to use Swiper assets locally, you can directly download them from https://www.jsdelivr.com/package/npm/swiper
 
 ## Add Swiper HTML Layout
 


### PR DESCRIPTION
unpkg is unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues). I switched the documentation over to [jsDelivr](https://www.jsdelivr.com/) since it's actively maintained and is much more reliable due to its [fallback system](https://www.jsdelivr.com/network/infographic). I don't think there's really a stable future for unpkg unless it gets picked up again. 😅 