### PR TITLE
Fix a Typo on element.mdx

### DIFF
--- a/src/pages/element.mdx
+++ b/src/pages/element.mdx
@@ -225,7 +225,7 @@ All event handler arguments are passed as array in `event.detail`:
 
 ## Pagination, Navigation, Scrollbar
 
-If you don't pass these modules elements in parameters (e.g. `scrollbar.el`, `pagination.el`), it will render them atuomatically, if module parameter is specified:
+If you don't pass these modules elements in parameters (e.g. `scrollbar.el`, `pagination.el`), it will render them automatically, if module parameter is specified:
 
 ```html
 <!-- enable navigation, pagination, scrollbar -->


### PR DESCRIPTION
fix a typo on the element.mdx
(from `atuomatically` to `automatically`)