### PR TITLE
fix: remove sponsor list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ public/demos/**/*.html
 !public/demos/images
 
 tsconfig.json
+
+public/sponsors-list.json

--- a/public/sponsors-list.json
+++ b/public/sponsors-list.json
@@ -1,5 +1,15 @@
 [
   {
+    "createdAt": "2023-06-06T20:00:00.000Z",
+    "title": "Kayakstore is the premier Swedish e-commerce destination for fishing gear and outdoor products",
+    "link": "https://www.kayakstore.se/",
+    "plan": "Sponsor",
+    "ref": "https://opencollective.com/kayakstore",
+    "image": "kayakstore.png",
+    "endDate": "",
+    "active": true
+  },
+  {
     "createdAt": "2023-06-01T20:00:00.000Z",
     "title": "DashTickets NZ online pokies for real money in New Zealand",
     "link": "https://dashtickets.nz/online-pokies-real-money/",


### PR DESCRIPTION
I mentioned that in https://github.com/nolimits4web/swiper-website/pull/329/files sponsored list created, this probably needs to be in gitignore