### PR TITLE
fix: make dark scroll bar in dark theme in Chromium-based browsers

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -35,6 +35,8 @@
   --color-orange: #8c5000;
 }
 .dark {
+  color-scheme: dark;
+  
   --color-primary-shade: #82acff;
   --color-primary-tint: #d4e2ff;
   --color-primary-rgb: 171, 199, 255;


### PR DESCRIPTION
<details><summary>Before:</summary>

![image](https://github.com/nolimits4web/swiper-website/assets/19418601/a17d6f48-bb55-4ecb-95e0-4817b75eebb2)

</details>

<details>
<summary>After:</summary>

![image](https://github.com/nolimits4web/swiper-website/assets/19418601/3052f1b0-e770-45aa-96c2-f145ad370fb2)

</details>