### PR TITLE
Superfluous "value" loop

### DIFF
--- a/src/demos/310-thumbs-gallery-loop/vue/src/App.vue
+++ b/src/demos/310-thumbs-gallery-loop/vue/src/App.vue
@@ -7,7 +7,7 @@
     :loop="true"
     :spaceBetween="10"
     :navigation="true"
-    :thumbs="{ swiper: thumbsSwiper.value }"
+    :thumbs="{ swiper: thumbsSwiper }"
     :modules="modules"
     class="mySwiper2"
   >


### PR DESCRIPTION
## Related:
Similar PR: https://github.com/nolimits4web/swiper-website/pull/401

## Description
Must be removed 'value', because it is not needed in 'template'